### PR TITLE
Add target and rel attributes to profile a links

### DIFF
--- a/src/components/Profile/Profile.js
+++ b/src/components/Profile/Profile.js
@@ -102,7 +102,11 @@ const Profile = ({ profileView, logOut, userId }) => {
             <p>{getUserData.getUserStats.myersBrigg.description}</p>
 
             <div className="link-container">
-              <a className="type-link" href={getUserData.getUserStats.myersBrigg.link}>Learn More</a>
+              <a className="type-link" 
+                href={getUserData.getUserStats.myersBrigg.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                >Learn More</a>
             </div>
 
           </div>
@@ -114,7 +118,11 @@ const Profile = ({ profileView, logOut, userId }) => {
             <p>{getUserData.getUserStats.enneagram.description}</p>
 
             <div className="link-container">
-              <a className="type-link" href={getUserData.getUserStats.enneagram.link}>Learn More</a>
+              <a className="type-link" 
+                href={getUserData.getUserStats.enneagram.link}
+                target="_blank"
+                rel="noopener noreferrer"
+              >Learn More</a>
             </div>
 
           </div>


### PR DESCRIPTION
# Thank you for pushing your code!
## What (if any) features are you implementing?
- This branch fixes the links in the profile view.
- Now, when a user clicks the "learn more" links under each personality summary, the link opens in a new browser window instead of in the apps window. 
- This helps keep the user signed in and able to use the app while they explore more about their personality types.

## What (if anything) did you refactor?
- The <a> tags in the return of the profile component.

## Were there any issues that arose?
- na

## Is there anything that you need from your teammates?
- na

## Any other comments, questions, or concerns?
- na

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor

## How Has This Been Tested?
- [x] open index.html
- [ ] console.log()
- [ ] dev tools
- [ ] Cypress

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas